### PR TITLE
Add repository and homepage to package.json

### DIFF
--- a/dokz/package.json
+++ b/dokz/package.json
@@ -11,6 +11,12 @@
         "spec": "tests/**.ts",
         "timeout": 9999999999
     },
+    "repository": {
+        "type": "git",
+        "url": "remorses/dokz",
+        "directory": "dokz"
+    },
+    "homepage": "https://dokz.site",
     "files": [
         "/dist/*",
         "/esm/*"


### PR DESCRIPTION
Benefits:

* https://www.npmjs.com/package/dokz will show links to github and the website
* Search engine indexing can improve
* It will be possible to use shortcuts like `npm repo dokz` or [`njt dokz i`](https://njt.now.sh/)

Other potential enhancements in project metadata:

* It'd be great to include README into the published artifact, so that it appeared at https://www.npmjs.com/package/dokz
* Listing tags in `package.json` can improve package discoverability on npm
* Adding license file and possibly changing license from `ISC` to `MIT` or `BSD` will improve clarity on dokz IP
* Configuring `prettier` and [`prettier-plugin-packagejson`](https://www.npmjs.com/package/prettier-plugin-packagejson) / [`prettier-plugin-sh`](https://www.npmjs.com/package/prettier-plugin-sh) can ease collaboration with other contributors

Happy to help with the last point if you are interested 😉